### PR TITLE
withTheme and makeStyles implementation with customizable css properties.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch React JS App",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import {
   Link as TextLink,
   SelectList,
 } from './lib/package/components';
+import NumericalStepper from './lib/package/components/Stepper/NumericalStepper';
 
 const handleSelectItem = selectedItem => {
   console.log('selectedItem', selectedItem);
@@ -24,6 +25,14 @@ const items = [
   { id: 6, value: 6, display: '6th item' },
   { id: 7, value: 7, display: '7th Item' },
 ];
+
+const overrideDefaultStepperStyles = () => {
+  return {
+    label: {
+      color: '#9ACD32', // yellow,
+    },
+  };
+};
 
 const App = () => {
   return (
@@ -87,6 +96,17 @@ const App = () => {
         type="primary"
         items={items}
         onSelect={selectedOption => handleSelectItem(selectedOption)}
+      />
+      <br />
+      <br />
+      <NumericalStepper
+        id="3"
+        overrides={overrideDefaultStepperStyles()}
+        labelText="Numerical stepper with style overrides"
+        helperText="This is a helper message"
+        mask={[/\d/, /\d/]}
+        onIncrease={() => {}}
+        onDecrease={() => {}}
       />
     </AAAPrimaryTheme>
   );

--- a/src/lib/package/components/Label/Label.js
+++ b/src/lib/package/components/Label/Label.js
@@ -1,17 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import _ from 'lodash';
+import { withTheme, makeStyles } from '@material-ui/core/styles';
 import MUIInputLabel from '@material-ui/core/InputLabel';
 import cx from 'clsx';
 
-const styleClasses = theme => ({
+const styleClasses = makeStyles({
   root: {
-    color: theme.palette.colorVariables.BLACK,
+    color: props =>
+      _.get(
+        props,
+        'overrides.label.color',
+        props.theme.palette.colorVariables.BLACK
+      ),
     display: 'block',
     marginBottom: -8,
-    fontFamily: theme.typography.fontFamily,
-    fontWeight: theme.typography.fontWeight,
-    ...theme.typography.body1,
+    fontFamily: props => props.theme.typography.fontFamily,
+    fontWeight: props => props.theme.typography.fontWeight,
+    ...props => props.theme.typography.body1,
   },
   formControl: {
     position: 'relative',
@@ -28,18 +34,12 @@ type propTypes = {
   disabled?: PropTypes.bool,
   error?: PropTypes.bool,
   focused?: PropTypes.bool,
-  id: PropTypes.string,
+  id: PropTypes.string
 };
 
-function Label({
-    children,
-    classes,
-    className,
-    disabled,
-    error,
-    focused,
-    id,
-  }): propTypes {
+function Label(props): propTypes {
+  const { children, className, disabled, error, focused, id } = props;
+  const classes = styleClasses(props);
   return (
     <MUIInputLabel
       className={cx('InputLabel', className)}
@@ -61,4 +61,4 @@ Label.defaultProps = {
   className: '',
 };
 
-export default withStyles(styleClasses, { index: 0, withTheme: true })(Label);
+export default withTheme(Label);

--- a/src/lib/package/components/Stepper/NumericalStepper.js
+++ b/src/lib/package/components/Stepper/NumericalStepper.js
@@ -16,8 +16,6 @@ import NumericInput from '../Input/NumericInput/NumericInput';
 
 import {
   overrideStepperLabel,
-  overrideStepperIcon,
-  overrideInputWrapper,
   styleClasses,
 } from './NumericalStepperStyles';
 
@@ -75,11 +73,11 @@ const NumericalStepper = (props: propTypes) => {
           <RemoveIcon
             data-quid={`RemoveIcon-${id}`}
             disabled={disabled}
-            style={overrideStepperIcon(props).stepperIcon}
+            className={classes.stepperIcon}
           />
         </StepperButton>
 
-        <div style={overrideInputWrapper().stepperInputWrapper}>
+        <div className={classes.stepperInputWrapper}>
           <NumericInput
             id={`NumericalStepperInput-${id}`}
             centerText
@@ -99,7 +97,7 @@ const NumericalStepper = (props: propTypes) => {
         >
           <MUIAddIcon
             data-quid={`AddIcon-${id}`}
-            style={overrideStepperIcon(props).stepperIcon}
+            className={classes.stepperIcon}
           />
         </StepperButton>
       </div>

--- a/src/lib/package/components/Stepper/NumericalStepper.js
+++ b/src/lib/package/components/Stepper/NumericalStepper.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { withTheme } from '@material-ui/styles';
 
 // Material UI Components
 import MUIFormControl from '@material-ui/core/FormControl';
@@ -15,57 +15,11 @@ import StepperButton from '../Button/Button';
 import NumericInput from '../Input/NumericInput/NumericInput';
 
 import {
-  AAA_CSS_INLINE,
-  AAA_CSS_MIDDLE,
-} from '../../constants/cssConstants';
-
-
-const styleClasses = theme => ({
-  stepperIcon: {
-    width: 24,
-    height: '100%',
-    color: theme.palette.primary.main,
-  },
-  stepperInputWrapper: {
-    display: 'inline-block',
-    width: 78,
-  },
-  stepperLabel: {
-    color: theme.palette.colorVariables.BLACK,
-    marginTop: 8,
-    fontSize: '16px',
-    [theme.breakpoints.up('md')]: {
-      fontSize: '18px',
-    },
-  },
-  actionWrapper: {
-    margin: '16px 0 6px 0',
-  },
-  helperText: {
-    color: theme.palette.colorVariables.GRAY,
-    marginTop: 8,
-    '& span': {
-      fontSize: 14,
-      [theme.breakpoints.up('md')]: {
-        fontSize: 16,
-      },
-    },
-  },
-  error: {
-    color: theme.palette.error.main,
-    fontSize: 14,
-    [theme.breakpoints.up('md')]: {
-      fontSize: '16px',
-    },
-    '& svg': {
-      display: `${AAA_CSS_INLINE}`,
-      fontSize: 20,
-      marginLeft: 8,
-      marginRight: 8,
-      verticalAlign: `${AAA_CSS_MIDDLE}`,
-    },
-  },
-});
+  overrideStepperLabel,
+  overrideStepperIcon,
+  overrideInputWrapper,
+  styleClasses,
+} from './NumericalStepperStyles';
 
 type propTypes = {
   id: PropTypes.string.isRequired,
@@ -75,14 +29,13 @@ type propTypes = {
   labelText?: PropTypes.string,
   helperText?: PropTypes.string,
   mask?: [], // Pass through
-  onIncrease: (React.SyntheticEvent) => void,
-  onDecrease: (React.SyntheticEvent) => void,
-  value?: PropTypes.number,
+  onIncrease: React.SyntheticEvent => void,
+  onDecrease: React.SyntheticEvent => void,
+  value?: PropTypes.number
 };
 
-const NumericalStepper = (props:propTypes) => {
+const NumericalStepper = (props: propTypes) => {
   const {
-    classes,
     disabled,
     disableWarning,
     error,
@@ -94,13 +47,17 @@ const NumericalStepper = (props:propTypes) => {
     onDecrease,
     value,
   } = props;
+
+  const classes = styleClasses(props);
+
   return (
     <MUIFormControl
       id={id}
       disabled={disabled}
-      classes={classes.root}
+      classes={{ root: classes.root }}
     >
       <Label
+        overrides={overrideStepperLabel(props)}
         id={`NumericalStepperLabel-${id}`}
         disabled={false}
         error={false}
@@ -118,11 +75,11 @@ const NumericalStepper = (props:propTypes) => {
           <RemoveIcon
             data-quid={`RemoveIcon-${id}`}
             disabled={disabled}
-            className={classes.stepperIcon}
+            style={overrideStepperIcon(props).stepperIcon}
           />
         </StepperButton>
 
-        <div className={classes.stepperInputWrapper}>
+        <div style={overrideInputWrapper().stepperInputWrapper}>
           <NumericInput
             id={`NumericalStepperInput-${id}`}
             centerText
@@ -142,11 +99,11 @@ const NumericalStepper = (props:propTypes) => {
         >
           <MUIAddIcon
             data-quid={`AddIcon-${id}`}
-            className={classes.stepperIcon}
+            style={overrideStepperIcon(props).stepperIcon}
           />
         </StepperButton>
       </div>
-      
+
       <FormFieldMeta
         id={`NumericalStepperMeta-${id}`}
         disableWarning={disableWarning}
@@ -167,6 +124,4 @@ NumericalStepper.defaultProps = {
   value: 1,
 };
 
-export default withStyles(styleClasses, { index: 0, withTheme: true })(
-  NumericalStepper
-);
+export default withTheme(NumericalStepper);

--- a/src/lib/package/components/Stepper/NumericalStepper.test.js
+++ b/src/lib/package/components/Stepper/NumericalStepper.test.js
@@ -196,33 +196,20 @@ describe('Style Overrides', () => {
   it('renders correct overrides for stepper decrease button', () => {
     const decreaseStepperIcon = customizedWrapper
       .find(Button)
-      .find('ForwardRef(SvgIcon)[data-quid="RemoveIcon-1"]')
+      .find('svg[data-quid="RemoveIcon-1"]')
       .first()
       .props();
 
-    expect(decreaseStepperIcon.style.width).to.equal(24);
-    expect(decreaseStepperIcon.style.height).to.equal('100%');
-    expect(decreaseStepperIcon.style.color).to.equal(AAA_COLOR_MAIN_BLUE);
+    expect(decreaseStepperIcon.className).to.contain('makeStyles-stepperIcon');
   });
 
-  it('renders correct overrides for stepper decrease button', () => {
+  it('renders correct overrides for stepper increase button', () => {
     const increaseStepperIcon = customizedWrapper
       .find(Button)
-      .find('ForwardRef(SvgIcon)[data-quid="AddIcon-1"]')
+      .find('svg[data-quid="AddIcon-1"]')
       .first()
       .props();
 
-    expect(increaseStepperIcon.style.width).to.equal(24);
-    expect(increaseStepperIcon.style.height).to.equal('100%');
-    expect(increaseStepperIcon.style.color).to.equal(AAA_COLOR_MAIN_BLUE);
-  });
-});
-
-describe('Additional style tests : No Mounting needed', () => {
-  it('renders sets correct styling for stepper input wrapper', () => {
-    const inputWrapper = overrideInputWrapper();
-
-    expect(inputWrapper.stepperInputWrapper.display).to.equal('inline-block');
-    expect(inputWrapper.stepperInputWrapper.width).to.equal(78);
+    expect(increaseStepperIcon.className).to.contain('makeStyles-stepperIcon');
   });
 });

--- a/src/lib/package/components/Stepper/NumericalStepper.test.js
+++ b/src/lib/package/components/Stepper/NumericalStepper.test.js
@@ -7,12 +7,16 @@ import MUIFormControl from '@material-ui/core/FormControl';
 // Material UI Components
 import AAAPrimaryTheme from '../AAAPrimaryTheme/AAAPrimaryTheme';
 import NumericalStepper from './NumericalStepper';
+import { overrideInputWrapper } from './NumericalStepperStyles';
 import NumericInput from '../Input/NumericInput/NumericInput';
 
 // Components
 import Button from '../Button/Button';
 import Label from '../Label/Label';
 import FormFieldMeta from '../Form/FormFieldMeta/FormFieldMeta';
+
+// constants
+import { AAA_COLOR_MAIN_BLUE } from '../../constants/colors';
 
 const createNumericalStepper = props => {
   return mount(
@@ -67,8 +71,12 @@ describe('Numerical Stepper', () => {
 
     it('renders an increase and decrease button', () => {
       expect(wrapper.find(Button)).to.have.lengthOf(2);
-      expect(wrapper.find('button[data-quid="DecreaseStepper-1"]')).to.have.lengthOf(1);
-      expect(wrapper.find('button[data-quid="IncreaseStepper-1"]')).to.have.lengthOf(1);
+      expect(
+        wrapper.find('button[data-quid="DecreaseStepper-1"]')
+      ).to.have.lengthOf(1);
+      expect(
+        wrapper.find('button[data-quid="IncreaseStepper-1"]')
+      ).to.have.lengthOf(1);
       expect(wrapper.find('svg[data-quid="AddIcon-1"]')).to.have.lengthOf(1);
     });
 
@@ -90,29 +98,131 @@ describe('Numerical Stepper', () => {
 
     it('renders a numeric input with a unique data-quid', () => {
       expect(wrapper.find(NumericInput)).to.have.lengthOf(1);
-      expect(wrapper.find('input[data-quid="BaseInput-NumericalStepperInput-1"]')).to.have.lengthOf(1);
+      expect(
+        wrapper.find('input[data-quid="BaseInput-NumericalStepperInput-1"]')
+      ).to.have.lengthOf(1);
     });
 
     it('renders an error message', () => {
-      expect(wrapper.find('svg[data-quid="FormFieldMetaReportProblem-NumericalStepperMeta-1"]')).to.have.lengthOf(1);
-      expect(wrapper.find('p[data-quid="FormFieldMetaErrorText-NumericalStepperMeta-1"]')).to.have.lengthOf(1);
-      expect(wrapper.find('p[data-quid="FormFieldMetaErrorText-NumericalStepperMeta-1"]').text()).to.equal('This is an error text');
+      expect(
+        wrapper.find(
+          'svg[data-quid="FormFieldMetaReportProblem-NumericalStepperMeta-1"]'
+        )
+      ).to.have.lengthOf(1);
+      expect(
+        wrapper.find(
+          'p[data-quid="FormFieldMetaErrorText-NumericalStepperMeta-1"]'
+        )
+      ).to.have.lengthOf(1);
+      expect(
+        wrapper
+          .find('p[data-quid="FormFieldMetaErrorText-NumericalStepperMeta-1"]')
+          .text()
+      ).to.equal('This is an error text');
     });
 
     it('renders a helper message', () => {
       expect(
-        wrapper.find('p[data-quid="FormFieldMetaHelperText-NumericalStepperMeta-1"]')
+        wrapper.find(
+          'p[data-quid="FormFieldMetaHelperText-NumericalStepperMeta-1"]'
+        )
       ).to.have.lengthOf(1);
       expect(
-        wrapper.find('p[data-quid="FormFieldMetaHelperText-NumericalStepperMeta-1"]').text()
+        wrapper
+          .find('p[data-quid="FormFieldMetaHelperText-NumericalStepperMeta-1"]')
+          .text()
       ).to.equal('This is a helper message');
     });
 
     it('renders label text', () => {
-      expect(wrapper.find('label[data-quid="Label-NumericalStepperLabel-1"]')).to.have.lengthOf(1);
-      expect(wrapper.find('label[data-quid="Label-NumericalStepperLabel-1"]').text()).to.equal(
-        'This is a numerical stepper'
-      );
+      expect(
+        wrapper.find('label[data-quid="Label-NumericalStepperLabel-1"]')
+      ).to.have.lengthOf(1);
+      expect(
+        wrapper.find('label[data-quid="Label-NumericalStepperLabel-1"]').text()
+      ).to.equal('This is a numerical stepper');
     });
+  });
+});
+
+describe('Style Overrides', () => {
+  let customizedWrapper;
+  beforeEach(() => {
+    const overrideDefaultStepperLabelStyles = () => {
+      return {
+        label: {
+          color: '#9ACD32',
+        },
+      };
+    };
+    const customizedWrapperProps = () => {
+      return {
+        id: '1',
+        labelText: 'This is a numerical stepper',
+        helperText: 'This is a helper message',
+        error: 'This is an error text',
+        value: 10,
+        onIncrease: onIncreaseSpy,
+        onDecrease: onDecreaseSpy,
+      };
+    };
+    customizedWrapper = mount(
+      <AAAPrimaryTheme>
+        <NumericalStepper
+          overrides={overrideDefaultStepperLabelStyles()}
+          {...customizedWrapperProps()}
+        />
+      </AAAPrimaryTheme>
+    );
+  });
+  afterEach(() => {
+    customizedWrapper.unmount();
+  });
+
+  it('renders correct overrides for stepper label', () => {
+    const labelNode = customizedWrapper
+      .find(Label)
+      .find('#NumericalStepperLabel-1')
+      .first();
+
+    const styles = labelNode.props().overrides.label;
+
+    expect(styles.color).to.equal('#9ACD32');
+    expect(styles.marginTop).to.equal(8);
+    expect(styles.fontSize).to.equal(16);
+    expect(styles['@media (min-width:768px)'].fontSize).to.equal(18);
+  });
+
+  it('renders correct overrides for stepper decrease button', () => {
+    const decreaseStepperIcon = customizedWrapper
+      .find(Button)
+      .find('ForwardRef(SvgIcon)[data-quid="RemoveIcon-1"]')
+      .first()
+      .props();
+
+    expect(decreaseStepperIcon.style.width).to.equal(24);
+    expect(decreaseStepperIcon.style.height).to.equal('100%');
+    expect(decreaseStepperIcon.style.color).to.equal(AAA_COLOR_MAIN_BLUE);
+  });
+
+  it('renders correct overrides for stepper decrease button', () => {
+    const increaseStepperIcon = customizedWrapper
+      .find(Button)
+      .find('ForwardRef(SvgIcon)[data-quid="AddIcon-1"]')
+      .first()
+      .props();
+
+    expect(increaseStepperIcon.style.width).to.equal(24);
+    expect(increaseStepperIcon.style.height).to.equal('100%');
+    expect(increaseStepperIcon.style.color).to.equal(AAA_COLOR_MAIN_BLUE);
+  });
+});
+
+describe('Additional style tests : No Mounting needed', () => {
+  it('renders sets correct styling for stepper input wrapper', () => {
+    const inputWrapper = overrideInputWrapper();
+
+    expect(inputWrapper.stepperInputWrapper.display).to.equal('inline-block');
+    expect(inputWrapper.stepperInputWrapper.width).to.equal(78);
   });
 });

--- a/src/lib/package/components/Stepper/NumericalStepperStyles.js
+++ b/src/lib/package/components/Stepper/NumericalStepperStyles.js
@@ -5,6 +5,7 @@ import { AAA_CSS_INLINE, AAA_CSS_MIDDLE } from '../../constants/cssConstants';
 // If overrides need to be passed down to child components
 // extract it into a method so makeStyles dynamic class naming
 // will not be used.
+
 export const overrideStepperLabel = props => {
   return {
     label: {
@@ -22,27 +23,18 @@ export const overrideStepperLabel = props => {
   };
 };
 
-export const overrideStepperIcon = props => {
-  return {
-    stepperIcon: {
-      width: 24,
-      height: '100%',
-      color: props.theme.palette.primary.main,
-    },
-  };
-};
-
-export const overrideInputWrapper = () => {
-  return {
-    stepperInputWrapper: {
-      display: 'inline-block',
-      width: 78,
-    },
-  };
-};
 
 // IF the style is part of Material UI API keep it inside styleClasses
 export const styleClasses = makeStyles({
+  stepperInputWrapper: {
+    display: 'inline-block',
+    width: 78,
+  },
+  stepperIcon: {
+    width: 24,
+    height: '100%',
+    color: props => props.theme.palette.primary.main,
+  },
   actionWrapper: {
     margin: '16px 0 6px 0',
   },

--- a/src/lib/package/components/Stepper/NumericalStepperStyles.js
+++ b/src/lib/package/components/Stepper/NumericalStepperStyles.js
@@ -1,0 +1,73 @@
+import _ from 'lodash';
+import { makeStyles } from '@material-ui/styles';
+import { AAA_CSS_INLINE, AAA_CSS_MIDDLE } from '../../constants/cssConstants';
+
+// If overrides need to be passed down to child components
+// extract it into a method so makeStyles dynamic class naming
+// will not be used.
+export const overrideStepperLabel = props => {
+  return {
+    label: {
+      color: _.get(
+        props,
+        'overrides.label.color',
+        props.theme.palette.colorVariables.BLACK
+      ),
+      marginTop: 8,
+      fontSize: 16,
+      [props.theme.breakpoints.up('md')]: {
+        fontSize: 18,
+      },
+    },
+  };
+};
+
+export const overrideStepperIcon = props => {
+  return {
+    stepperIcon: {
+      width: 24,
+      height: '100%',
+      color: props.theme.palette.primary.main,
+    },
+  };
+};
+
+export const overrideInputWrapper = () => {
+  return {
+    stepperInputWrapper: {
+      display: 'inline-block',
+      width: 78,
+    },
+  };
+};
+
+// IF the style is part of Material UI API keep it inside styleClasses
+export const styleClasses = makeStyles({
+  actionWrapper: {
+    margin: '16px 0 6px 0',
+  },
+  helperText: {
+    color: props => props.theme.palette.colorVariables.GRAY,
+    marginTop: 8,
+    '& span': {
+      fontSize: 14,
+      [props => props.theme.breakpoints.up('md')]: {
+        fontSize: 16,
+      },
+    },
+  },
+  error: {
+    color: props => props.theme.palette.error.main,
+    fontSize: 14,
+    [props => props.theme.breakpoints.up('md')]: {
+      fontSize: '16px',
+    },
+    '& svg': {
+      display: `${AAA_CSS_INLINE}`,
+      fontSize: 20,
+      marginLeft: 8,
+      marginRight: 8,
+      verticalAlign: `${AAA_CSS_MIDDLE}`,
+    },
+  },
+});

--- a/src/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/src/storyshots/__snapshots__/storyshots.test.js.snap
@@ -4,6 +4,10 @@ exports[`Storyshots Atomic|Button all buttons 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots Atomic|Button dynamic button 1`] = `ReactWrapper {}`;
 
+exports[`Storyshots Atomic|Button primary and secondary 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots Atomic|Input Input 1`] = `ReactWrapper {}`;
+
 exports[`Storyshots Atomic|Input input 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots Atomic|Input states 1`] = `ReactWrapper {}`;


### PR DESCRIPTION
Revised styling using withTheme and makeStyles. Moved the stylings to a different file, utilized the combination of inline styles but still using makeStyles together with Themes to increase testability of css rules

### Links
https://autoclub.atlassian.net/browse/ACL-7

### Description
**For all overriding built in styles** like focused, error, disabled etc.  we use the makeStyle and define the css rules inside the makeStyle constructor.

**For all custom styles,  if the style is intended to be passed down to the child component** we define the styles in the exportable ES6 function. To be passed down to `overrides `prop of the component. If customization is needed we could pass the props in that method.
We are creating a function for the styles so we can have a way to test individual styles as compare with assigning classes via className which would just give a random classname like `makeStyle-cssRuleName-randomNumber`  which is hard to test due to its dynamic nature. We can't be sure that the className we are testing is the same className generated by makeStyles. And there's no way to extract css rules out of it. 

**If the child component we are styling comes from material UI and not one of our wrappers** we will assign our ES6 function to the `style `prop. That way we can unit test the css rules like mentioned above.

### How to test
 yarn storybook

### Additional Notes
_What sort of notes are important to the reviewer?`_

### Explanation of Jest/Unit Testing
_What sorts of unit tests have been written?_