### PR TITLE
Hotfix/field input

### DIFF
--- a/dist/components/Input/BaseInput/BaseInput.test.js
+++ b/dist/components/Input/BaseInput/BaseInput.test.js
@@ -19,7 +19,7 @@ import BaseInput from './BaseInput';
 import AAAPrimaryTheme from '../../AAAPrimaryTheme/AAAPrimaryTheme';
 
 // Test Utilities
-import { getDOMNodeComputedStyle } from '../../../../../../test/DOM';
+import { getDOMNodeComputedStyle } from '../../../../test/DOM';
 
 // Constants
 import {

--- a/src/lib/internal/live_demos/Form.js
+++ b/src/lib/internal/live_demos/Form.js
@@ -39,15 +39,48 @@ export const demo = `class FormDemo extends React.Component {
           <Form
             validations={FormDemo.validations()}
             onSubmit={FormDemo.handleFormValueSubmission}
-            render={({ allRequiredFieldsHaveBeenVisited, handleSubmit }) => {
+            render={({ allRequiredFieldsHaveBeenVisitedOrHaveValues, handleSubmit }) => {
               return (
                 <form onSubmit={handleSubmit}>
                   <FormGroup>
                     <FormInput 
-                      name="firstName"
+                      id="disabledInitial"
+                      disabled
+                      initialValue="some-unique-identifier-0000101"
+                      labelName="Disabled, initial value"
+                      type="text"
+                    />
+                  </FormGroup>
+                  <FormGroup>
+                    <FormInput 
+                      id="initialValue"
+                      initialValue="Prefilled value"
+                      labelName="Initial value"
+                      type="text"
+                    />
+                  </FormGroup>
+                  <FormGroup>
+                    <FormInput 
+                      autoFocus
                       id="firstName"
                       labelName="First name"
-                      helperText="If you have a first name, please enter it here"
+                      type="text"
+                    />
+                  </FormGroup>
+                  <FormGroup>
+                    <FormInput 
+                      id="lastName"
+                      labelName="Last name"
+                      helperText="Not required"
+                      type="text"
+                    />
+                  </FormGroup>
+                  <FormGroup>
+                    <FormNumericInput 
+                      id="dob"
+                      labelName="Date of birth"
+                      mask={[/\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, /\d/, /\d/]}
+                      helperText="mm/dd/yyyy"
                       type="text"
                     />
                   </FormGroup>
@@ -69,8 +102,8 @@ export const demo = `class FormDemo extends React.Component {
                   </FormGroup>
                   <ButtonGroup>
                     <Button
-                      disabled={!allRequiredFieldsHaveBeenVisited}
-                      fadeUp={allRequiredFieldsHaveBeenVisited}
+                      disabled={!allRequiredFieldsHaveBeenVisitedOrHaveValues}
+                      fadeUp={allRequiredFieldsHaveBeenVisitedOrHaveValues}
                       type="submit"
                     >
                       Submit

--- a/src/lib/package/components/Button/Button.tsx
+++ b/src/lib/package/components/Button/Button.tsx
@@ -21,6 +21,7 @@ interface OptionalProps {
   forwardedRef?: React.RefObject<any>,
   isIconButton?: boolean,
   href?: string,
+  type?: 'button' | 'submit',
 }
 
 const defaultProps:OptionalProps = {
@@ -30,6 +31,7 @@ const defaultProps:OptionalProps = {
   fadeUp: false,
   isIconButton: false,
   href: '',
+  type: 'button',
 };
 
 const styleClasses = (theme:Theme):{
@@ -133,12 +135,13 @@ const Button:React.FunctionComponent<RequiredProps & OptionalProps> = ({
   children,
   className,
   classes,
+  color,
   disabled,
   fadeUp,
-  id,
-  color,
-  href,
   forwardedRef,
+  href,
+  id,
+  type,
   onClick,
   isIconButton,
 }) => {
@@ -165,6 +168,7 @@ const Button:React.FunctionComponent<RequiredProps & OptionalProps> = ({
       variant="contained"
       href={href}
       ref={forwardedRef}
+      type={type}
       onClick={onClick}
     >
       {children}

--- a/src/lib/package/components/Form/Form.tsx
+++ b/src/lib/package/components/Form/Form.tsx
@@ -19,34 +19,25 @@ interface RequiredProps {
 
 class FormDecorator extends React.Component<RequiredProps> {
   /**
-   * A UX requirement to check there is at least some value in all fields
-   * @param  {Function} options.formRenderProps.form.getRegisteredFields - the form field names
-   * @param  {Object} options.values - current key/values of form state
-   * @return {Boolean}
-   */
-  static allFieldsHaveValues({ formRenderProps }: {formRenderProps:FormRenderProps}){
-    const { form, values } = formRenderProps;
-    const registeredFields = form.getRegisteredFields();
-    return registeredFields.every(fieldKey => !!values[fieldKey]);
-  }
-
-  /**
-   * A UX requirement to check that all required fields have been visited
+   * A UX requirement to check that all required fields have been visited or have values
    * @param  {Function} options.formRenderProps.form.getRegisteredFields - the form field names
    * @param  {Function} options.validations - the form field names
    * @param  {Object} options.values - current key/values of form state
    * @return {Boolean}
    */
-  static allRequiredFieldsHaveBeenVisited(
+  static allRequiredFieldsHaveBeenVisitedOrHaveValues(
     { formRenderProps, validations }
     : {formRenderProps:FormRenderProps, validations: any })
   {
-    const { visited } = formRenderProps;
+    const { values, visited } = formRenderProps;
     const validationFields = Object.keys(validations);
     const requiredFields = validationFields.filter(fieldKey => {
       return Object.prototype.hasOwnProperty.call(validations[fieldKey], 'required');
     });
-    return requiredFields.every(fieldKey => !!visited[fieldKey]);
+
+    return requiredFields.every(fieldKey => {
+      return !!values[fieldKey] || !!visited[fieldKey];
+    });
   }
 
   /**
@@ -60,8 +51,7 @@ class FormDecorator extends React.Component<RequiredProps> {
     : {formRenderProps:FormRenderProps, validations: any})
   {
     return Object.assign({}, formRenderProps, {
-      allFieldsHaveValues: this.allFieldsHaveValues({ formRenderProps }),
-      allRequiredFieldsHaveBeenVisited: this.allRequiredFieldsHaveBeenVisited({ formRenderProps, validations }),
+      allRequiredFieldsHaveBeenVisitedOrHaveValues: this.allRequiredFieldsHaveBeenVisitedOrHaveValues({ formRenderProps, validations }),
     });
   }
 
@@ -73,13 +63,11 @@ class FormDecorator extends React.Component<RequiredProps> {
 
   static decorateRender(
     renderFn:(decorator:any) => {
-      allFieldsHaveValues: boolean,
-      allRequiredFieldsHaveBeenVisited: boolean,
+      allRequiredFieldsHaveBeenVisitedOrHaveValues: boolean,
     },
     validations:any
    ):(formRenderProps:any) => {
-      allFieldsHaveValues: boolean,
-      allRequiredFieldsHaveBeenVisited: boolean,
+      allRequiredFieldsHaveBeenVisitedOrHaveValues: boolean,
     }{
     return (formRenderProps) => {
       // Form Render Props are passed to the render method of the Form

--- a/src/lib/package/components/Form/FormInput/FormInput.test.js
+++ b/src/lib/package/components/Form/FormInput/FormInput.test.js
@@ -1,0 +1,52 @@
+/* global describe, it */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+// Components
+import AAAPrimaryTheme from '../../AAAPrimaryTheme/AAAPrimaryTheme';
+import Form from '../Form';
+import FormInput from './FormInput';
+
+function renderInputWithProps({ id }){
+  return function renderInput({ handleSubmit }){
+    return (
+      <form onSubmit={handleSubmit}>
+        <FormInput
+           id={id}
+        />
+      </form>
+    );
+  };
+}
+
+function createFormAndFormInputWithTheme(props) {
+  return mount(
+      <AAAPrimaryTheme>
+        <Form
+          onSubmit={() => {}}
+          validations={{}}
+          render={renderInputWithProps(props)}
+        />
+      </AAAPrimaryTheme>
+  );
+}
+
+describe('FormInput', () => {
+  const props = {
+    id: 'some-unique-identifier',
+  };
+  const FormComponent = createFormAndFormInputWithTheme(props);
+  const FormInputComponent = FormComponent.find(FormInput);
+  const FormInputNode = FormInputComponent.getDOMNode();
+  
+  describe('rendering HTML element', () => {
+    it('includes a class name of "FormInput" on the HTML element', () => {
+      expect(FormInputNode.className).to.include('FormInput');
+    });
+
+    it('includes an HTML class property when passed a React className prop', () => {
+      expect(FormInputNode.className).to.include(props.className);
+    });
+  });
+});

--- a/src/lib/package/components/Form/FormInput/FormInput.test.js
+++ b/src/lib/package/components/Form/FormInput/FormInput.test.js
@@ -2,18 +2,20 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import { Field } from 'react-final-form';
 
 // Components
 import AAAPrimaryTheme from '../../AAAPrimaryTheme/AAAPrimaryTheme';
+import BaseInput from '../../Input/BaseInput/BaseInput';
 import Form from '../Form';
 import FormInput from './FormInput';
 
-function renderInputWithProps({ id }){
+function renderInputWithProps(props){
   return function renderInput({ handleSubmit }){
     return (
       <form onSubmit={handleSubmit}>
         <FormInput
-           id={id}
+           {...props}
         />
       </form>
     );
@@ -38,15 +40,44 @@ describe('FormInput', () => {
   };
   const FormComponent = createFormAndFormInputWithTheme(props);
   const FormInputComponent = FormComponent.find(FormInput);
-  const FormInputNode = FormInputComponent.getDOMNode();
+  const FieldComponent = FormComponent.find(Field);
+  const BaseInputComponent = FormComponent.find(BaseInput);
   
-  describe('rendering HTML element', () => {
-    it('includes a class name of "FormInput" on the HTML element', () => {
-      expect(FormInputNode.className).to.include('FormInput');
+  describe('React element', () => {
+    it('has required prop values for id', () => {
+      expect(FormInputComponent.props().id).to.equal(props.id);
     });
 
-    it('includes an HTML class property when passed a React className prop', () => {
-      expect(FormInputNode.className).to.include(props.className);
+    it('passes a required "name" prop to the underlying <Field> when passed an id', () => {
+      expect(FieldComponent.props().name).to.equal(props.id);
+    });
+
+    it('forwards a ref to the underlying <BaseInput> when not specified as prop', () => {
+      expect(BaseInputComponent.props().forwardedRef.current.id).to.equal(props.id);
+    });
+  });
+
+  describe('Optional props', () => {
+    it('forwards a ref to the underlying <BaseInput> when "forwardedRef" props is passed', () => {
+      const optionalProps = {
+        id: 'some-unique-identifier-for-optiona-prop-test-case',
+        forwardedRef: React.createRef(),
+      };
+      createFormAndFormInputWithTheme(optionalProps);
+      expect(optionalProps.forwardedRef.current.id).to.equal(optionalProps.id);
+    });
+  });
+
+  describe('Initial value', () => {
+    const initialProps = {
+      id: 'initial-unique-identifier',
+      initialValue: 'This is INITIALLY what I meant',
+    };
+    const InitialFormComponent = createFormAndFormInputWithTheme(initialProps);
+    const InitialBaseInputComponent = InitialFormComponent.find(BaseInput);
+
+    it('has an initial value received in its props', () => {
+      expect(InitialBaseInputComponent.props().value).to.equal(initialProps.initialValue);
     });
   });
 });

--- a/src/lib/package/components/Form/FormInput/FormInput.test.js
+++ b/src/lib/package/components/Form/FormInput/FormInput.test.js
@@ -24,13 +24,13 @@ function renderInputWithProps(props){
 
 function createFormAndFormInputWithTheme(props) {
   return mount(
-      <AAAPrimaryTheme>
-        <Form
-          onSubmit={() => {}}
-          validations={{}}
-          render={renderInputWithProps(props)}
-        />
-      </AAAPrimaryTheme>
+    <AAAPrimaryTheme>
+      <Form
+        onSubmit={() => {}}
+        validations={{}}
+        render={renderInputWithProps(props)}
+      />
+    </AAAPrimaryTheme>
   );
 }
 

--- a/src/lib/package/components/Form/FormInput/FormInput.tsx
+++ b/src/lib/package/components/Form/FormInput/FormInput.tsx
@@ -44,7 +44,8 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
    * @return {React.RefObject<any>}
    */
   getInputRef(){
-    return this.props.forwardedRef || this.inputRef;
+    const { forwardedRef } = this.props;
+    return forwardedRef || this.inputRef;
   }
 
   /**
@@ -73,13 +74,12 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
    */
   handleFieldClear(
     { input }:{input: {name: string, onChange: (val:string) => void}},
-    inputRef: React.RefObject<any>,
+    ref: React.RefObject<any>,
   ){
     return () => {
       const { formState } = this.props;
       const { name, onChange } = input;
       const { mutators: { setFieldTouched }} = formState;
-      const ref = this.getInputRef();
 
       setFieldTouched(name, false);
       onChange('');

--- a/src/lib/package/components/Form/FormInput/FormInput.tsx
+++ b/src/lib/package/components/Form/FormInput/FormInput.tsx
@@ -17,12 +17,12 @@ interface OptionalProps {
 
 
 /**
- * FormInput is a functional <Field> Wrapper around <BaseInput />
+ * FormInput is a  <Field> Wrapper around <BaseInput />
  * FormInput's responsibility is to 
  * 1. map ReactFinalForm's exposed "fieldProps" to <BaseInput>'s props
  * 2. Have logic to determine when an error is shown
  * 
- * By exposing the form's state via hooks, we are able to tap into custom mutators and other form state
+ * By exposing the form's state via HOC, we are able to tap into custom mutators and other form state
  * defined on our top-level <Form> component and plucked from context
  */
 class FormInput extends React.Component<RequiredProps & OptionalProps> {
@@ -77,8 +77,8 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
    * Renders the base input field
    * NOTE: It is required to pass a named function to component
    * ... if you pass an anonymous function it will re-create the component
-   * @param  {[type]} fieldProps:any [description]
-   * @return {[type]}                [description]
+   * @param  {Object} fieldProps - react final form field props
+   * @return {React.Component}
    */
   renderFieldComponent(fieldProps:any){
     const { forwardedRef } = this.props;

--- a/src/lib/package/components/Form/FormInput/FormInput.tsx
+++ b/src/lib/package/components/Form/FormInput/FormInput.tsx
@@ -7,14 +7,13 @@ import BaseInput from '../../Input/BaseInput/BaseInput';
 
 interface RequiredProps {
   id: string,
-  name: string,
 };
 
 interface OptionalProps {
+  initialValue?: string | number,
   formState?: any, // Decorator
   forwardedRef?: React.RefObject<any>,
 };
-
 
 /**
  * FormInput is a  <Field> Wrapper around <BaseInput />
@@ -26,6 +25,10 @@ interface OptionalProps {
  * defined on our top-level <Form> component and plucked from context
  */
 class FormInput extends React.Component<RequiredProps & OptionalProps> {
+  static defaultProps:OptionalProps = {
+    initialValue: '',
+  }
+
   constructor(props:RequiredProps & OptionalProps){
     super(props);
     this.handleFormFieldChange = this.handleFormFieldChange.bind(this);
@@ -96,15 +99,15 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
   }
 
   render(){
-    const { name } = this.props;
+    const { id, initialValue } = this.props;
     return (
       <Field
-        name={name}
+        name={id}
+        initialValue={initialValue}
         component={this.renderFieldComponent}
       />
     );
   }
 }
-
 
 export default withFormState(FormInput);

--- a/src/lib/package/components/Form/FormInput/FormInput.tsx
+++ b/src/lib/package/components/Form/FormInput/FormInput.tsx
@@ -25,15 +25,26 @@ interface OptionalProps {
  * defined on our top-level <Form> component and plucked from context
  */
 class FormInput extends React.Component<RequiredProps & OptionalProps> {
+  inputRef:React.RefObject<any> = React.createRef();
+
   static defaultProps:OptionalProps = {
     initialValue: '',
   }
 
   constructor(props:RequiredProps & OptionalProps){
     super(props);
+    this.getInputRef = this.getInputRef.bind(this);
     this.handleFormFieldChange = this.handleFormFieldChange.bind(this);
     this.handleFieldClear = this.handleFieldClear.bind(this);
     this.renderFieldComponent = this.renderFieldComponent.bind(this);
+  }
+
+  /**
+   * Receives the ref for the underlying input
+   * @return {React.RefObject<any>}
+   */
+  getInputRef(){
+    return this.props.forwardedRef || this.inputRef;
   }
 
   /**
@@ -62,16 +73,18 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
    */
   handleFieldClear(
     { input }:{input: {name: string, onChange: (val:string) => void}},
-    inputRef?: {current: {focus: () => void}}
-    ){
+    inputRef: React.RefObject<any>,
+  ){
     return () => {
       const { formState } = this.props;
       const { name, onChange } = input;
       const { mutators: { setFieldTouched }} = formState;
+      const ref = this.getInputRef();
+
       setFieldTouched(name, false);
       onChange('');
-      if (inputRef && inputRef.current){
-        inputRef.current.focus();
+      if (ref && ref.current){
+        ref.current.focus();
       }
     };
   }
@@ -84,15 +97,16 @@ class FormInput extends React.Component<RequiredProps & OptionalProps> {
    * @return {React.Component}
    */
   renderFieldComponent(fieldProps:any){
-    const { forwardedRef } = this.props;
+    const ref = this.getInputRef();
     const { meta } = fieldProps;
+    
     return (
       <BaseInput
         {...fieldProps.input}
         error={meta.touched && meta.error}
         onChange={this.handleFormFieldChange(fieldProps)}
-        onClear={this.handleFieldClear(fieldProps, forwardedRef)}
-        forwardedRef={forwardedRef}
+        onClear={this.handleFieldClear(fieldProps, ref)}
+        forwardedRef={ref}
         {...this.props} // Passed props take highest priority
       />
     );

--- a/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
+++ b/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
@@ -7,16 +7,17 @@ import NumericInput from '../../Input/NumericInput/NumericInput';
 
 interface RequiredProps {
   id: string,
-  name: string,
 };
 
 interface OptionalProps {
+  defaultValue?: string | number,
+  initialValue?: string | number,
   formState?: any, // Decorator
   forwardedRef?: React.RefObject<any>
 };
 
 /**
- * FormNumericInput is a  <Field> Wrapper around <BaseInput />
+ * FormNumericInput is a <Field> Wrapper around <BaseInput />
  * FormNumericInput's responsibility is to 
  * 1. map ReactFinalForm's exposed "fieldProps" to <BaseInput>'s props
  * 2. Have logic to determine when an error is shown
@@ -96,11 +97,11 @@ class FormNumericInput extends React.Component<RequiredProps & OptionalProps> {
   }
 
   render(){
-    const { name } = this.props;
+    const { id } = this.props;
 
     return (
       <Field
-        name={name}
+        name={id}
         component={this.renderFieldComponent}
       />
     );

--- a/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
+++ b/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
@@ -17,9 +17,9 @@ interface OptionalProps {
 };
 
 /**
- * FormNumericInput is a <Field> Wrapper around <BaseInput />
+ * FormNumericInput is a <Field> Wrapper around <NumericInput />
  * FormNumericInput's responsibility is to 
- * 1. map ReactFinalForm's exposed "fieldProps" to <BaseInput>'s props
+ * 1. map ReactFinalForm's exposed "fieldProps" to <NumericInput>'s props
  * 2. Have logic to determine when an error is shown
  * 
  * By exposing the form's state via HOC, we are able to tap into custom mutators and other form state

--- a/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
+++ b/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
@@ -1,7 +1,8 @@
-import React, { useRef } from 'react';
-import { Field, useForm } from 'react-final-form';
+import React from 'react';
+import { Field } from 'react-final-form';
 
 // Components
+import withFormState from '../withFormState';
 import NumericInput from '../../Input/NumericInput/NumericInput';
 
 interface RequiredProps {
@@ -10,84 +11,101 @@ interface RequiredProps {
 };
 
 interface OptionalProps {
+  formState?: any, // Decorator
   forwardedRef?: React.RefObject<any>
 };
 
-
 /**
- * Form field change interceptor calls a form effect "setFieldTouched"
- * @param  {Object} options.input - fieldProps.input
- * @param  {Object} formState - global form state
- * @return {Function} decoratored onChange
- */
-function handleFormFieldChange(
-  { input }:{input: {name: string, onChange: (evt:React.SyntheticEvent) => void}},
-  formState:any
- ):(evt:React.SyntheticEvent) => void {
-  return (evt) => {
-    const { name, onChange } = input;
-    const { mutators: { setFieldTouched }} = formState;
-    setFieldTouched(name, false);
-    onChange(evt);
-  };
-}
-
-/**
- * Handles clearing of input value
- * @param  {Object} options.input - fieldProps.input
- * @param  {Object} formState - global form state
- * @param  {Object} inputRef - reference to the underlying input
- * @return {Function} onClear handler
- */
-function handleFieldClear(
-  { input }:{input: {name: string, onChange: (val:string) => void}},
-  formState:any,
-  inputRef: React.RefObject<any>
-  ) {
-  return () => {
-    const { name, onChange } = input;
-    const { mutators: { setFieldTouched }} = formState;
-    setFieldTouched(name, false);
-    onChange('');
-    if (inputRef){
-      inputRef.current.focus();
-    }
-  };
-}
-
-/**
- * FormNumericInput is a functional <Field> Wrapper around <NumericInput />
+ * FormNumericInput is a  <Field> Wrapper around <BaseInput />
  * FormNumericInput's responsibility is to 
- * 1. map ReactFinalForm's exposed "fieldProps" to <NumericInput>'s props
+ * 1. map ReactFinalForm's exposed "fieldProps" to <BaseInput>'s props
  * 2. Have logic to determine when an error is shown
  * 
- * By exposing the form's state via hooks, we are able to tap into custom mutators and other form state
+ * By exposing the form's state via HOC, we are able to tap into custom mutators and other form state
  * defined on our top-level <Form> component and plucked from context
  */
-  const FormNumericInput:React.FunctionComponent<RequiredProps & OptionalProps> = (props) => {
-  const { forwardedRef } = props;
-  const inputRef = forwardedRef || useRef(null);
-  const formState = useForm();
-  const { name } = props;
-  return (
-    <Field
-      name={name}
-      component={(fieldProps) => {
-        const { meta } = fieldProps;
-        return (
-          <NumericInput
-            {...fieldProps.input}
-            error={meta.touched && meta.error}
-            onChange={handleFormFieldChange(fieldProps, formState)}
-            onClear={handleFieldClear(fieldProps, formState, inputRef)}
-            forwardedRef={inputRef}
-            {...props} // Passed props take highest priority
-          />
-        );
-      }}
-    />
-  );
-};
+class FormNumericInput extends React.Component<RequiredProps & OptionalProps> {
+  constructor(props:RequiredProps & OptionalProps){
+    super(props);
+    this.handleFormFieldChange = this.handleFormFieldChange.bind(this);
+    this.handleFieldClear = this.handleFieldClear.bind(this);
+    this.renderFieldComponent = this.renderFieldComponent.bind(this);
+  }
+
+  /**
+   * Form field change interceptor calls a form effect "setFieldTouched"
+   * @param  {Object} options.input - fieldProps.input
+   * @param  {Object} formState - global form state
+   * @return {Function} decoratored onChange
+   */
+  handleFormFieldChange(
+    { input }:{input: {name: string, onChange: (evt:React.SyntheticEvent) => void}},
+   ):(evt:React.SyntheticEvent) => void {
+    return (evt) => {
+      const { formState } = this.props;
+      const { name, onChange } = input;
+      const { mutators: { setFieldTouched }} = formState;
+      setFieldTouched(name, false);
+      onChange(evt);
+    };
+  }
+
+  /**
+   * Handles clearing of input value
+   * @param  {Object} options.input - fieldProps.input
+   * @param  {Object} formState - global form state
+   * @param  {Object} inputRef - reference to the underlying input
+   * @return {Function} onClear handler
+   */
+  handleFieldClear(
+    { input }:{input: {name: string, onChange: (val:string) => void}},
+    inputRef?: React.RefObject<any>
+    ) {
+    return () => {
+      const { formState } = this.props;
+      const { name, onChange } = input;
+      const { mutators: { setFieldTouched }} = formState;
+      setFieldTouched(name, false);
+      onChange('');
+      if (inputRef){
+        inputRef.current.focus();
+      }
+    };
+  }
+
+  /**
+   * Renders the base input field
+   * NOTE: It is required to pass a named function to component
+   * ... if you pass an anonymous function it will re-create the component
+   * @param  {Object} fieldProps - react final form field props
+   * @return {React.Component}
+   */
+  renderFieldComponent(fieldProps:any){
+    const { forwardedRef } = this.props;
+    const { meta } = fieldProps;
+    return (
+      <NumericInput
+        {...fieldProps.input}
+        error={meta.touched && meta.error}
+        onChange={this.handleFormFieldChange(fieldProps)}
+        onClear={this.handleFieldClear(fieldProps, forwardedRef)}
+        forwardedRef={forwardedRef}
+        {...this.props} // Passed props take highest priority
+      />
+    );
+  }
+
+  render(){
+    const { name } = this.props;
+
+    return (
+      <Field
+        name={name}
+        component={this.renderFieldComponent}
+      />
+    );
+  }
+}
 
 
-export default FormNumericInput;
+export default withFormState(FormNumericInput);

--- a/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
+++ b/src/lib/package/components/Form/FormNumericInput/FormNumericInput.tsx
@@ -10,7 +10,6 @@ interface RequiredProps {
 };
 
 interface OptionalProps {
-  defaultValue?: string | number,
   initialValue?: string | number,
   formState?: any, // Decorator
   forwardedRef?: React.RefObject<any>

--- a/src/lib/package/components/Form/withFormState.tsx
+++ b/src/lib/package/components/Form/withFormState.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useForm } from 'react-final-form';
+
+const withFormState = (Component:any) => (props:any) => (
+  <Component 
+    formState={useForm()} {...props}
+  />
+);
+
+export default withFormState;

--- a/src/lib/package/components/Input/BaseInput/BaseInput.test.js
+++ b/src/lib/package/components/Input/BaseInput/BaseInput.test.js
@@ -36,8 +36,7 @@ function createInput(props) {
 
 function getFakeProps(override) {
   return { // Required
-    id: 'input-unique-identifier', // used for unique identifier and data tracking
-    name: 'input-unique-name', // used for form value
+    id: 'input-unique-identifier', // used for form value name & unique identifier for data-tracking
     ...override,
   };
 }

--- a/src/lib/package/components/Label/Label.tsx
+++ b/src/lib/package/components/Label/Label.tsx
@@ -67,7 +67,6 @@ const Label:React.FunctionComponent<RequiredProps & OptionalProps> = ({
     focused,
     id,
   }) => {
-  console.log('children', children);
   return (
     <MUIInputLabel
       className={cx('InputLabel', className)}

--- a/stories/Form/Form.stories.js
+++ b/stories/Form/Form.stories.js
@@ -18,6 +18,9 @@ import {
 } from '../../src/lib/package/components';
 
 const VALIDATIONS = {
+  initialValue: {
+    required: 'This field is required',
+  },
   firstName: {
     required: 'First name is required',
     'max_length[24]': 'Too long. Do you have a nickname?',
@@ -54,13 +57,29 @@ stories
               <Form
                 validations={VALIDATIONS}
                 onSubmit={handleFormValueSubmission}
-                render={({ allRequiredFieldsHaveBeenVisited, handleSubmit }) => {
+                render={({ allRequiredFieldsHaveBeenVisitedOrHaveValues, handleSubmit }) => {
                   return (
                     <form onSubmit={handleSubmit}>
                       <FormGroup>
                         <FormInput 
+                          id="disabledInitial"
+                          disabled
+                          initialValue="some-unique-identifier-0000101"
+                          labelName="Disabled, initial value"
+                          type="text"
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <FormInput 
+                          id="initialValue"
+                          initialValue="Prefilled value"
+                          labelName="Initial value"
+                          type="text"
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <FormInput 
                           autoFocus
-                          name="firstName"
                           id="firstName"
                           labelName="First name"
                           type="text"
@@ -68,7 +87,6 @@ stories
                       </FormGroup>
                       <FormGroup>
                         <FormInput 
-                          name="lastName"
                           id="lastName"
                           labelName="Last name"
                           helperText="Not required"
@@ -77,7 +95,6 @@ stories
                       </FormGroup>
                       <FormGroup>
                         <FormNumericInput 
-                          name="dob"
                           id="dob"
                           labelName="Date of birth"
                           mask={[/\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, /\d/, /\d/]}
@@ -103,8 +120,8 @@ stories
                       </FormGroup>
                       <ButtonGroup>
                         <Button
-                          disabled={!allRequiredFieldsHaveBeenVisited}
-                          fadeUp={allRequiredFieldsHaveBeenVisited}
+                          disabled={!allRequiredFieldsHaveBeenVisitedOrHaveValues}
+                          fadeUp={allRequiredFieldsHaveBeenVisitedOrHaveValues}
                           type="submit"
                         >
                           Submit

--- a/stories/Form/Form.stories.js
+++ b/stories/Form/Form.stories.js
@@ -14,6 +14,7 @@ import {
   Form,
   FormGroup,
   FormInput,
+  FormNumericInput,
 } from '../../src/lib/package/components';
 
 const VALIDATIONS = {
@@ -24,6 +25,9 @@ const VALIDATIONS = {
   },
   lastName: {
     alpha_dash_dot_space: 'Name can only contain letters, dashes, periods, and spaces',
+  },
+  dob: {
+    required: 'Date of birth is required',
   },
   password: {
     required: 'Password is required',
@@ -68,6 +72,16 @@ stories
                           id="lastName"
                           labelName="Last name"
                           helperText="Not required"
+                          type="text"
+                        />
+                      </FormGroup>
+                      <FormGroup>
+                        <FormNumericInput 
+                          name="dob"
+                          id="dob"
+                          labelName="Date of birth"
+                          mask={[/\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, ' ', '/', ' ', /\d/, /\d/, /\d/, /\d/]}
+                          helperText="mm/dd/yyyy"
                           type="text"
                         />
                       </FormGroup>


### PR DESCRIPTION
### Links
No Jira Ticket

### Description
--**The problem**:  
We were experiencing a blur for field inputs when imported into another project.
--**The Fix**
The wrapper around a field input needs to be a NAMED function. If it's an anonymous arrow function then it will recreated the underlying input.
There are some workarounds to fix this problem as listed below:
1. We made FormInput a class component. We did this so we can have a class method that has access to `this`
2. Since we are not in a functional component, we lost access to `useRef` hook and `useForm` hook. Right now, I've created an additional HOC decorator to expose that hook. We might have to do that with useRef as well.
3. We are still experiencing the blur issue with Number component which we use for masking. This will require a deeper dive

### How to test
`yarn storybook`

### Additional Notes
Let's discuss if you want more clarity

### Explanation of Jest/Unit Testing
- Creates a FormInput test for wrapper with initialValue tests